### PR TITLE
c legger til arbeidssokerregistrering-for-veileder i accessPolicy

### DIFF
--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -48,6 +48,9 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: arbeidssokerregistrering-for-veileder
+          cluster: dev-gcp
+          namespace: paw
         - application: arbeidssokerregistrering-veileder
           cluster: dev-gcp
           namespace: paw

--- a/nais/prod.yaml
+++ b/nais/prod.yaml
@@ -48,6 +48,9 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: arbeidssokerregistrering-for-veileder
+          cluster: prod-gcp
+          namespace: paw
         - application: arbeidssokerregistrering-veileder
           cluster: prod-gcp
           namespace: paw


### PR DESCRIPTION
Den nye veileder-appen for arbeidssøkerregistrering trenger tilgang til proxyen