### PR TITLE
veilarboppfølging i gcp

### DIFF
--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -47,9 +47,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: arbeidssokerregistrering-for-veileder
-          cluster: dev-gcp
-          namespace: paw
         - application: dp-soknadsdialog
           cluster: dev-gcp
           namespace: teamdagpenger

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -62,7 +62,8 @@ spec:
     outbound:
       rules:
         - application: veilarboppfolging
-          namespace: pto
+          namespace: poao
+          cluster: dev-gcp
         - application: veilarbperson
           namespace: pto
         - application: veilarbveileder

--- a/nais/prod.yaml
+++ b/nais/prod.yaml
@@ -47,9 +47,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: arbeidssokerregistrering-for-veileder
-          cluster: prod-gcp
-          namespace: paw
         - application: dp-soknadsdialog
           cluster: prod-gcp
           namespace: teamdagpenger

--- a/nais/prod.yaml
+++ b/nais/prod.yaml
@@ -62,7 +62,8 @@ spec:
     outbound:
       rules:
         - application: veilarboppfolging
-          namespace: pto
+          namespace: poao
+          cluster: prod-gcp
         - application: veilarbperson
           namespace: pto
         - application: veilarbveileder


### PR DESCRIPTION
Endrer namespace og cluster for reglene til veilarboppfolging så det pekes mot gcp